### PR TITLE
feat: Upgrade platform constructs and pnpm

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'pnpm'
 
       - run: corepack enable
@@ -88,7 +88,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'pnpm'
 
       - run: corepack enable

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript-eslint": "^8.59.2"
   },
   "dependencies": {
-    "@orcabus/platform-cdk-constructs": "1.5.3",
+    "@orcabus/platform-cdk-constructs": "1.5.4",
     "aws-cdk-lib": "^2.253.1",
     "constructs": "^10.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript-eslint": "^8.59.2"
   },
   "dependencies": {
-    "@orcabus/platform-cdk-constructs": "1.5.2",
+    "@orcabus/platform-cdk-constructs": "1.5.3",
     "aws-cdk-lib": "^2.253.1",
     "constructs": "^10.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "organization": true
   },
   "license": "MIT",
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",
@@ -38,7 +38,7 @@
     "typescript-eslint": "^8.59.2"
   },
   "dependencies": {
-    "@orcabus/platform-cdk-constructs": "1.3.1",
+    "@orcabus/platform-cdk-constructs": "1.5.0",
     "aws-cdk-lib": "^2.253.1",
     "constructs": "^10.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript-eslint": "^8.59.2"
   },
   "dependencies": {
-    "@orcabus/platform-cdk-constructs": "1.5.0",
+    "@orcabus/platform-cdk-constructs": "1.5.1",
     "aws-cdk-lib": "^2.253.1",
     "constructs": "^10.6.0"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typescript-eslint": "^8.59.2"
   },
   "dependencies": {
-    "@orcabus/platform-cdk-constructs": "1.5.1",
+    "@orcabus/platform-cdk-constructs": "1.5.2",
     "aws-cdk-lib": "^2.253.1",
     "constructs": "^10.6.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.5.0
-        version: 1.5.0(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.5.1
+        version: 1.5.1(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib:
         specifier: ^2.253.1
         version: 2.253.1(constructs@10.6.0)
@@ -436,8 +436,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@orcabus/platform-cdk-constructs@1.5.0':
-    resolution: {integrity: sha512-SeiizEWX7e8Vh6lzggNsRNpnyDStJR91btjSs3TRyD10PX1lHH/n92xXLjPIAKTkUF6OZrAHQ85aHcbZj8eA4A==}
+  '@orcabus/platform-cdk-constructs@1.5.1':
+    resolution: {integrity: sha512-Dh6KSj2ZLuXxOIbNkn64uUVuOLuTLeWXh6cRn1beXJdTLZJqvrMxnvERmCGmHgW1p1g4HiIB3DSD4b0lClXndA==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2312,7 +2312,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.5.0(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.5.1(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib: 2.253.1(constructs@10.6.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.5.1
-        version: 1.5.1(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.5.2
+        version: 1.5.2(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib:
         specifier: ^2.253.1
         version: 2.253.1(constructs@10.6.0)
@@ -436,8 +436,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@orcabus/platform-cdk-constructs@1.5.1':
-    resolution: {integrity: sha512-Dh6KSj2ZLuXxOIbNkn64uUVuOLuTLeWXh6cRn1beXJdTLZJqvrMxnvERmCGmHgW1p1g4HiIB3DSD4b0lClXndA==}
+  '@orcabus/platform-cdk-constructs@1.5.2':
+    resolution: {integrity: sha512-dRdIh9j1ZCNqRfxmaklcyN/yYm3yCopTA+nF51oqn0j0m1B5PLTiaXAcatIuZTZijrF/j94Hb6lKg+YmJoGPVw==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2312,7 +2312,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.5.1(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.5.2(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib: 2.253.1(constructs@10.6.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.5.3
-        version: 1.5.3(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.5.4
+        version: 1.5.4(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib:
         specifier: ^2.253.1
         version: 2.253.1(constructs@10.6.0)
@@ -436,8 +436,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@orcabus/platform-cdk-constructs@1.5.3':
-    resolution: {integrity: sha512-UErztSiCw+wEupOZzNaodaDliCJ8knZ0pzvS+bpdqmxfZ9Ke+JNhJnTP4JaxU1egh9VvxyU7oc2pWKhlGp3deg==}
+  '@orcabus/platform-cdk-constructs@1.5.4':
+    resolution: {integrity: sha512-e8UbmqSGRDQLKB38oVZdEYLrIMzSopFndTTLdJ446BwtHpr4fJbkbDzfjjFbZbp6MaTd8k9jGUCYzuJKSYPDvg==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2312,7 +2312,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.5.3(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.5.4(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib: 2.253.1(constructs@10.6.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.5.2
-        version: 1.5.2(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.5.3
+        version: 1.5.3(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib:
         specifier: ^2.253.1
         version: 2.253.1(constructs@10.6.0)
@@ -436,8 +436,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@orcabus/platform-cdk-constructs@1.5.2':
-    resolution: {integrity: sha512-dRdIh9j1ZCNqRfxmaklcyN/yYm3yCopTA+nF51oqn0j0m1B5PLTiaXAcatIuZTZijrF/j94Hb6lKg+YmJoGPVw==}
+  '@orcabus/platform-cdk-constructs@1.5.3':
+    resolution: {integrity: sha512-UErztSiCw+wEupOZzNaodaDliCJ8knZ0pzvS+bpdqmxfZ9Ke+JNhJnTP4JaxU1egh9VvxyU7oc2pWKhlGp3deg==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2312,7 +2312,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.5.2(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.5.3(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib: 2.253.1(constructs@10.6.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.3.1
-        version: 1.3.1(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 1.5.0
+        version: 1.5.0(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib:
         specifier: ^2.253.1
         version: 2.253.1(constructs@10.6.0)
@@ -436,8 +436,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@orcabus/platform-cdk-constructs@1.3.1':
-    resolution: {integrity: sha512-vCpPyoWUxM9w41wmpYpaXKjL0ErsIId8xd1xu4n7vuQoPcz4H6OwTV7mHAq6usCIwwy4NQXag4sDqimyw8uJPA==}
+  '@orcabus/platform-cdk-constructs@1.5.0':
+    resolution: {integrity: sha512-SeiizEWX7e8Vh6lzggNsRNpnyDStJR91btjSs3TRyD10PX1lHH/n92xXLjPIAKTkUF6OZrAHQ85aHcbZj8eA4A==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2312,7 +2312,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.3.1(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
+  '@orcabus/platform-cdk-constructs@1.5.0(@aws-cdk/aws-lambda-python-alpha@2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.195.0-alpha.0(aws-cdk-lib@2.253.1(constructs@10.6.0))(constructs@10.6.0)
       aws-cdk-lib: 2.253.1(constructs@10.6.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  unrs-resolver: true


### PR DESCRIPTION
-----
- Upgrades `@orcabus/platform-cdk-constructs` to version 1.5.0.
- Updates pnpm package manager to version 11.1.2.
- Configures `pnpm-workspace.yaml` to allow builds for `unrs-resolver`.