### PR TITLE
fix: Update JSONata merge expression

### DIFF
--- a/app/step-functions-templates/icav2_wes_asc_event_to_workflow_rsc_event_sfn_template.asl.json
+++ b/app/step-functions-templates/icav2_wes_asc_event_to_workflow_rsc_event_sfn_template.asl.json
@@ -49,7 +49,7 @@
       "Arguments": {
         "Entries": [
           {
-            "Detail": "{% /* Merge workflowRunStateChangeEvent with the status object */\n$merge(\n  $workflowRunStateChangeEvent,\n  {\n    \"status\": $status\n  }\n) %}",
+            "Detail": "{% /* Merge workflowRunStateChangeEvent with the status object */\n[\n  $workflowRunStateChangeEvent,\n  {\n    \"status\": $status\n  }\n] ~> $merge %}",
             "DetailType": "${__workflow_run_update_event_detail_type__}",
             "EventBusName": "${__event_bus_name__}",
             "Source": "${__stack_source__}"


### PR DESCRIPTION
-----
app/step-functions-templates/
-----
* Corrects the JSONata merge expression in `icav2_wes_asc_event_to_workflow_rsc_event_sfn_template.asl.json` to use the idiomatic `~> $merge` pipe operator.
