### PR TITLE
Skips empty read group processing

### DIFF
--- a/app/ecs/get_fastq_list_rows_from_bam/docker-entrypoint.sh
+++ b/app/ecs/get_fastq_list_rows_from_bam/docker-entrypoint.sh
@@ -218,6 +218,12 @@ while read -r rgid; do
     is_paired_end="false"
   fi
 
+  # May not be any reads in the bam file from this rgid
+  # Even if its in the header
+  if [[ ! -f "${SPLIT_PREFIX}_${rgid}.bamstat" ]]; then
+    continue
+  fi
+
   # Write to jsonl
   jq --null-input \
     --raw-output --compact-output \


### PR DESCRIPTION
Improves BAM file processing by skipping read groups that are present in the header but have no associated reads. This prevents further processing for read groups that would not generate a corresponding `bamstat` file, enhancing robustness.