### PR TITLE
Standardizes payload version handling

### DIFF
--- a/app/lambdas/validate_draft_complete_schema_py/validate_draft_complete_schema.py
+++ b/app/lambdas/validate_draft_complete_schema_py/validate_draft_complete_schema.py
@@ -115,10 +115,14 @@ def handler(event, context) -> Dict[str, bool]:
     :return:
     """
     # Get the event data
-    payload_version = event.get("payloadVersion", environ[DEFAULT_PAYLOAD_VERSION_ENV_VAR])
+    payload_version = event.get("payloadVersion")
     payload_data = event.get('data')
     workflow_run_id = event.get("workflowRunId", "")
     comment_error = event.get("addCommentOnError", False)
+
+    # Set payload version if not defined
+    if payload_version is None:
+        payload_version = environ[DEFAULT_PAYLOAD_VERSION_ENV_VAR]
 
     # Get the SSM parameters
     schema_registry = get_ssm_parameter_value(environ[SSM_REGISTRY_NAME_ENV_VAR])

--- a/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
+++ b/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
@@ -459,7 +459,7 @@
               "Choices": [
                 {
                   "Next": "Keep Original sequence data",
-                  "Condition": "{% $tags.fromBam %}",
+                  "Condition": "{% $tags.fromBam ? true : false %}",
                   "Comment": "From Bam (tags)"
                 }
               ],

--- a/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
+++ b/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
@@ -21,7 +21,7 @@
       "Arguments": {
         "FunctionName": "${__validate_draft_complete_schema_lambda_function_arn__}",
         "Payload": {
-          "payloadVersion": "{% $payload.version %}",
+          "payloadVersion": "{% $payload.version ? $payload.version : null %}",
           "data": "{% $data %}"
         }
       },

--- a/app/step-functions-templates/validate_draft_data_and_put_ready_event_sfn_template.asl.json
+++ b/app/step-functions-templates/validate_draft_data_and_put_ready_event_sfn_template.asl.json
@@ -21,7 +21,7 @@
       "Arguments": {
         "FunctionName": "${__validate_draft_complete_schema_lambda_function_arn__}",
         "Payload": {
-          "payloadVersion": "{% $payload.version %}",
+          "payloadVersion": "{% $payload.version ? $payload.version : null %}",
           "data": "{% $payloadData %}",
           "workflowRunId": "{% $workflowRunId %}",
           "addCommentOnError": true

--- a/infrastructure/stage/lambda/index.ts
+++ b/infrastructure/stage/lambda/index.ts
@@ -123,7 +123,7 @@ function buildLambda(scope: Construct, props: LambdaInput): LambdaObject {
 
   /*
     Special if the lambdaName is 'validateDraftCompleteSchema', we need to add in the ssm parameters
-    to the REGISTRY_NAME and SCHEMA_NAME
+    to the REGISTRY_NAME and SCHEMA_PATH
    */
   if (props.lambdaName === 'validateDraftCompleteSchema') {
     const draftSchemaName: SchemaNames = 'completeDataDraft';


### PR DESCRIPTION
Addresses inconsistencies in how payload versions are handled, especially when they might be null or undefined, and improves boolean condition evaluation in Step Functions.

- **Payload Versioning:**
  - Updates the `validateDraftCompleteSchema` lambda to explicitly check for a `None` payload version before falling back to the default environment variable, ensuring robust handling of missing or null values.
  - Modifies Step Functions to explicitly pass `null` for `payloadVersion` when it's not defined, aligning with the lambda's updated handling logic.

- **Step Functions Logic:**
  - Ensures explicit boolean evaluation for the `fromBam` condition within Step Functions, enhancing clarity and reliability.

- **Documentation:**
  - Corrects a minor typo in a lambda comment relating to `SCHEMA_PATH`.

Relates to bugfix/handle-empty-payload