### PR TITLE
Adds workflow version 2.3.0 support

### DIFF
--- a/infrastructure/stage/constants.ts
+++ b/infrastructure/stage/constants.ts
@@ -43,6 +43,7 @@ export const WORKFLOW_VERSION_TO_DEFAULT_ICAV2_PIPELINE_ID_MAP: Record<
   '2.0.0': 'a64126df-d8b2-4ec0-99df-1154f44a74ef',
   '2.1.0': 'ab6e1d62-1b5a-4b24-86b8-81ccf4bdc7a2',
   '2.2.0': '40b8005e-1473-4257-9949-cc8b42750cf0',
+  '2.3.0': 'fb07badf-dcba-4a8c-97a9-12e842b97dfb',
 };
 
 export const WORKFLOW_VERSION_TO_DEFAULT_HMF_REFERENCE_PATHS_MAP: Record<
@@ -55,6 +56,8 @@ export const WORKFLOW_VERSION_TO_DEFAULT_HMF_REFERENCE_PATHS_MAP: Record<
     's3://reference-data-503977275616-ap-southeast-2/refdata/hartwig/hmf-reference-data/hmftools/hmf_pipeline_resources.38_v2.1.0--1/',
   '2.2.0':
     's3://reference-data-503977275616-ap-southeast-2/refdata/hartwig/hmf-reference-data/hmftools/hmf_pipeline_resources.38_v2.2.0--3/',
+  '2.3.0':
+    's3://reference-data-503977275616-ap-southeast-2/refdata/hartwig/hmf-reference-data/hmftools/hmf_pipeline_resources.38_v2.3.0--2/',
 };
 
 export const GENOMES_MAP: Record<NotInBuiltInHmfReferenceGenomesType, Genome> = {
@@ -89,6 +92,13 @@ export const DEFAULT_WORKFLOW_INPUTS_BY_VERSION_MAP: Record<WorkflowVersionType,
     forceGenome: true,
   },
   '2.2.0': {
+    mode: 'wgts',
+    genome: 'GRCh38_umccr',
+    genomeVersion: '38',
+    genomeType: 'alt',
+    forceGenome: true,
+  },
+  '2.3.0': {
     mode: 'wgts',
     genome: 'GRCh38_umccr',
     genomeVersion: '38',

--- a/infrastructure/stage/interfaces.ts
+++ b/infrastructure/stage/interfaces.ts
@@ -44,7 +44,7 @@ export interface StatelessApplicationStackConfig {
 }
 
 /* Set versions */
-export type WorkflowVersionType = '2.0.0' | '2.1.0' | '2.2.0';
+export type WorkflowVersionType = '2.0.0' | '2.1.0' | '2.2.0' | '2.3.0';
 export type PayloadVersionType = '2025.08.05' | '2026.05.12';
 
 export const payloadVersionList: PayloadVersionType[] = ['2025.08.05', '2026.05.12'];


### PR DESCRIPTION
Introduces support for workflow version '2.3.0' by:
- Extending the `WorkflowVersionType` definition to include '2.3.0'.
- Configuring essential constants for the new version, such as the default ICAv2 pipeline ID, HMF reference data paths, and default workflow inputs.
This ensures the infrastructure correctly integrates and utilizes the specified resources for the '2.3.0' workflow.