### PR TITLE
fix: guard get_s3_key_prefix_by_project_id against ApiException and None

### DIFF
--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -20,7 +20,7 @@ Performs the following steps:
 """
 # Imports
 from pathlib import Path
-from typing import Dict, Tuple, cast, List
+from typing import Dict, Tuple, List
 import logging
 from os import environ
 from time import sleep
@@ -330,7 +330,29 @@ def handler(event, context) -> Dict[str, bool]:
         )
         return {"isValid": False}
 
-    project_prefix = cast(str, get_s3_key_prefix_by_project_id(project_id))
+    try:
+        project_prefix = get_s3_key_prefix_by_project_id(project_id)
+    except ApiException:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                f"Post schema validation failed: cannot resolve S3 key prefix for projectId '{project_id}'",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
+
+    if project_prefix is None:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                f"Post schema validation failed: no S3 key prefix configured for projectId '{project_id}'",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
 
     # Collect all failures
     all_failures: List[str] = []


### PR DESCRIPTION
## Summary

Adds defensive handling around `get_s3_key_prefix_by_project_id` in the `post_schema_validation` lambda.

The wrapica function can:
1. **Raise `ApiException`** — if the ICAv2 API call fails (network issues, auth problems, invalid project)
2. **Return `None`** — if the project has no storage configuration

Previously only `projectId is None` was guarded — an API failure or missing storage config would crash the lambda. Now we also:
- Catch `ApiException`
- Check for `None` return
- Write a descriptive comment to the workflow run record
- Return `{"isValid": false}` gracefully

## Related PRs

This fix is being applied consistently across all pipeline manager services:
- OrcaBus/service-arriba-wgts-rna-pipeline-manager
- OrcaBus/service-bclconvert-interop-qc-pipeline-manager
- OrcaBus/service-dragen-tso500-ctdna-pipeline-manager
- OrcaBus/service-dragen-wgts-dna-pipeline-manager
- OrcaBus/service-dragen-wgts-rna-pipeline-manager
- OrcaBus/service-oncoanalyser-wgts-dna-pipeline-manager
- OrcaBus/service-oncoanalyser-wgts-rna-pipeline-manager
- OrcaBus/service-sash-pipeline-manager